### PR TITLE
Update EOA validation logic

### DIFF
--- a/contracts/test/MockImplementation.sol
+++ b/contracts/test/MockImplementation.sol
@@ -26,7 +26,7 @@ contract MockImplementation {
         validatorList = _r1ValidatorsLinkedList().list();
     }
 
-    function implementation() external view returns (address) {
+    function implementationAddress() external view returns (address) {
         address impl;
         assembly {
             impl := and(sload(_IMPLEMENTATION_SLOT), 0xffffffffffffffffffffffffffffffffffffffff)

--- a/contracts/validators/EOAValidator.sol
+++ b/contracts/validators/EOAValidator.sol
@@ -14,10 +14,14 @@ contract EOAValidator is IK1Validator {
 
     /// @inheritdoc IK1Validator
     function validateSignature(
-        bytes32 signedHash,
+        bytes32 eip712Hash,
         bytes calldata signature
     ) external pure override returns (address signer) {
-        (signer, ) = signedHash.tryRecover(signature);
+        bytes32 ethSignedMessageHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", eip712Hash)
+        );
+        // Recover the signer
+        signer = ethSignedMessageHash.recover(signature);
     }
 
     /// @inheritdoc IERC165

--- a/subgraph/src/account-factory-v2.ts
+++ b/subgraph/src/account-factory-v2.ts
@@ -67,7 +67,7 @@ export function handleClaveAccountDeployed(
         account.realizedGain = ZERO;
     }
 
-    account.implementation = Bytes.fromHexString(
+    account.implementationAddress = Bytes.fromHexString(
         '0xf5bEDd0304ee359844541262aC349a6016A50bc6',
     );
     account.deployDate = event.block.timestamp;

--- a/subgraph/src/account-factory.ts
+++ b/subgraph/src/account-factory.ts
@@ -72,7 +72,7 @@ export function handleNewClaveAccount(event: NewClaveAccountEvent): void {
         account.invested = ZERO;
         account.realizedGain = ZERO;
     }
-    account.implementation = Bytes.fromHexString(
+    account.implementationAddress = Bytes.fromHexString(
         '0xdd4dD37B22Fc16DBFF3daB6Ecd681798c459f275',
     );
     account.deployDate = event.block.timestamp;

--- a/subgraph/src/account.ts
+++ b/subgraph/src/account.ts
@@ -62,6 +62,6 @@ export function handleUpgraded(event: UpgradedEvent): void {
     if (account == null) {
         return;
     }
-    account.implementation = event.params.newImplementation;
+    account.implementationAddress = event.params.newImplementation;
     account.save();
 }

--- a/test/clave.test.ts
+++ b/test/clave.test.ts
@@ -164,7 +164,7 @@ describe('Account no module no hook TEE validator', function () {
             expect(await account.listModules()).to.deep.eq(expectedModules);
             expect(await account.listHooks(false)).to.deep.eq(expectedHooks);
             expect(await account.listHooks(true)).to.deep.eq(expectedHooks);
-            expect(await account.implementation()).to.eq(
+            expect(await account.implementationAddress()).to.eq(
                 expectedImplementation,
             );
         });
@@ -1604,7 +1604,7 @@ describe('Account no module no hook TEE validator', function () {
 
                 await txReceipt.wait();
 
-                expect(await account.implementation()).to.eq(
+                expect(await account.implementationAddress()).to.eq(
                     await mockImplementation.getAddress(),
                 );
             });

--- a/test/utils/p256.ts
+++ b/test/utils/p256.ts
@@ -6,6 +6,7 @@
 import elliptic from 'elliptic';
 import { keccak256 } from 'ethers';
 import BN from 'bn.js';
+import { ethers } from 'ethers';
 
 export function genKey(): elliptic.ec.KeyPair {
     const ec = new elliptic.ec('p256');
@@ -39,18 +40,34 @@ export function encodePublicKeyK1(key: elliptic.ec.KeyPair): string {
 }
 
 export function sign(msg: string, key: elliptic.ec.KeyPair): string {
-    const buffer = Buffer.from(msg.slice(2), 'hex');
-    const signature = key.sign(buffer, { canonical: true });
-
-    const r = padToHex(signature.r, 64);
-    const s = padToHex(signature.s, 64);
-
     if (isSecp256k1(key.ec.curve)) {
-        const v = padToHex(new BN(signature.recoveryParam! + 27), 2);
-        return `0x${r}${s}${v}`;
+        // For secp256k1, use ethers.js for EIP-191 signing
+        const privateKey = padToHex(key.getPrivate().toString(16), 64);
+        const wallet = new ethers.Wallet(privateKey);
+        
+        // Remove '0x' prefix if present
+        const cleanMsg = msg.startsWith('0x') ? msg.slice(2) : msg;
+        
+        // Sign the message using ethers.js v6 (this applies EIP-191 automatically)
+        const signature = wallet.signMessageSync(ethers.getBytes('0x' + cleanMsg));
+        
+        // Split the signature
+        const { r, s, v } = ethers.Signature.from(signature);
+        
+        // Format the signature parts
+        const rHex = padToHex(r.slice(2), 64);  // remove '0x' and pad
+        const sHex = padToHex(s.slice(2), 64);  // remove '0x' and pad
+        const vHex = padToHex(v.toString(16), 2);
+        
+        return `0x${rHex}${sHex}${vHex}`;
+    } else {
+        // For non-secp256k1, directly sign the message
+        const signatureBuffer = Buffer.from(msg.slice(2), 'hex');
+        const signature = key.sign(signatureBuffer, { canonical: true });
+        const r = padToHex(signature.r.toString(16), 64);
+        const s = padToHex(signature.s.toString(16), 64);
+        return `0x${r}${s}`;
     }
-
-    return `0x${r}${s}`;
 }
 
 
@@ -59,6 +76,22 @@ function isSecp256k1(curve: any): boolean {
            curve.p.toString(16) === 'fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f';
 }
 
-function padToHex(value: BN | number, length: number): string {
-    return value.toString(16).padStart(length, '0');
+function padToHex(value: string | BN | number, length: number): string {
+    let hexString: string;
+
+    if (typeof value === 'string') {
+        // If it's already a string, just ensure it's a hex string
+        hexString = value.startsWith('0x') ? value.slice(2) : value;
+    } else if (BN.isBN(value)) {
+        // If it's a BN instance, convert to hex string
+        hexString = value.toString(16);
+    } else if (typeof value === 'number') {
+        // If it's a number, convert to hex string
+        hexString = value.toString(16);
+    } else {
+        throw new Error('Invalid input type for padToHex');
+    }
+
+    // Pad the hex string to the desired length
+    return hexString.padStart(length, '0');
 }


### PR DESCRIPTION
Every Ethereum wallet will sign messages via EIP-191, so we need to update our validator contract to account for this. Previously we were validating direct signatures which aren't allowed by any wallet providers.