### PR TITLE
Update EOA Validator to use EIP712 formatted data

### DIFF
--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-import {DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
-import {SystemContractsCaller} from '@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol';
-import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+import {DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
+import {SystemContractsCaller} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import {Errors} from './libraries/Errors.sol';
-import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
+import {Errors} from "./libraries/Errors.sol";
+import {IClaveRegistry} from "./interfaces/IClaveRegistry.sol";
 
 /**
  * @title Factory contract to create Clave accounts in zkSync Era
@@ -88,20 +88,21 @@ contract AccountFactory is Ownable {
         // }
 
         // Deploy the implementation contract
-        (bool success, bytes memory returnData) = SystemContractsCaller.systemCallWithReturndata(
-            uint32(gasleft()),
-            address(DEPLOYER_SYSTEM_CONTRACT),
-            uint128(0),
-            abi.encodeCall(
-                DEPLOYER_SYSTEM_CONTRACT.create2Account,
-                (
-                    salt,
-                    proxyBytecodeHash,
-                    abi.encode(implementationAddress),
-                    IContractDeployer.AccountAbstractionVersion.Version1
+        (bool success, bytes memory returnData) = SystemContractsCaller
+            .systemCallWithReturndata(
+                uint32(gasleft()),
+                address(DEPLOYER_SYSTEM_CONTRACT),
+                uint128(0),
+                abi.encodeCall(
+                    DEPLOYER_SYSTEM_CONTRACT.create2Account,
+                    (
+                        salt,
+                        proxyBytecodeHash,
+                        abi.encode(implementationAddress),
+                        IContractDeployer.AccountAbstractionVersion.Version1
+                    )
                 )
-            )
-        );
+            );
 
         if (!success) {
             revert Errors.DEPLOYMENT_FAILED();
@@ -113,7 +114,7 @@ contract AccountFactory is Ownable {
         // Initialize the account
         bool initializeSuccess;
 
-        assembly ('memory-safe') {
+        assembly ("memory-safe") {
             initializeSuccess := call(
                 gas(),
                 accountAddress,
@@ -160,7 +161,9 @@ contract AccountFactory is Ownable {
      * @notice Changes the implementation contract address
      * @param newImplementation address - Address of the new implementation contract
      */
-    function changeImplementation(address newImplementation) external onlyOwner {
+    function changeImplementation(
+        address newImplementation
+    ) external onlyOwner {
         implementationAddress = newImplementation;
 
         emit ImplementationChanged(newImplementation);
@@ -181,13 +184,16 @@ contract AccountFactory is Ownable {
      * @param salt bytes32 - Salt to be used for the account creation
      * @return accountAddress address - Address of the Clave account that would be created with the given salt
      */
-    function getAddressForSalt(bytes32 salt) external view returns (address accountAddress) {
-        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).getNewAddressCreate2(
-            address(this),
-            proxyBytecodeHash,
-            salt,
-            abi.encode(implementationAddress)
-        );
+    function getAddressForSalt(
+        bytes32 salt
+    ) external view returns (address accountAddress) {
+        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT)
+            .getNewAddressCreate2(
+                address(this),
+                proxyBytecodeHash,
+                salt,
+                abi.encode(implementationAddress)
+            );
     }
 
     /**
@@ -200,11 +206,12 @@ contract AccountFactory is Ownable {
         bytes32 salt,
         address _implementation
     ) external view returns (address accountAddress) {
-        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).getNewAddressCreate2(
-            address(this),
-            proxyBytecodeHash,
-            salt,
-            abi.encode(_implementation)
-        );
+        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT)
+            .getNewAddressCreate2(
+                address(this),
+                proxyBytecodeHash,
+                salt,
+                abi.encode(_implementation)
+            );
     }
 }

--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-import {DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
-import {SystemContractsCaller} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
+import {SystemContractsCaller} from '@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol';
+import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 
-import {Errors} from "./libraries/Errors.sol";
-import {IClaveRegistry} from "./interfaces/IClaveRegistry.sol";
+import {Errors} from './libraries/Errors.sol';
+import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
 
 /**
  * @title Factory contract to create Clave accounts in zkSync Era
@@ -88,21 +88,20 @@ contract AccountFactory is Ownable {
         // }
 
         // Deploy the implementation contract
-        (bool success, bytes memory returnData) = SystemContractsCaller
-            .systemCallWithReturndata(
-                uint32(gasleft()),
-                address(DEPLOYER_SYSTEM_CONTRACT),
-                uint128(0),
-                abi.encodeCall(
-                    DEPLOYER_SYSTEM_CONTRACT.create2Account,
-                    (
-                        salt,
-                        proxyBytecodeHash,
-                        abi.encode(implementationAddress),
-                        IContractDeployer.AccountAbstractionVersion.Version1
-                    )
+        (bool success, bytes memory returnData) = SystemContractsCaller.systemCallWithReturndata(
+            uint32(gasleft()),
+            address(DEPLOYER_SYSTEM_CONTRACT),
+            uint128(0),
+            abi.encodeCall(
+                DEPLOYER_SYSTEM_CONTRACT.create2Account,
+                (
+                    salt,
+                    proxyBytecodeHash,
+                    abi.encode(implementationAddress),
+                    IContractDeployer.AccountAbstractionVersion.Version1
                 )
-            );
+            )
+        );
 
         if (!success) {
             revert Errors.DEPLOYMENT_FAILED();
@@ -114,7 +113,7 @@ contract AccountFactory is Ownable {
         // Initialize the account
         bool initializeSuccess;
 
-        assembly ("memory-safe") {
+        assembly ('memory-safe') {
             initializeSuccess := call(
                 gas(),
                 accountAddress,
@@ -161,9 +160,7 @@ contract AccountFactory is Ownable {
      * @notice Changes the implementation contract address
      * @param newImplementation address - Address of the new implementation contract
      */
-    function changeImplementation(
-        address newImplementation
-    ) external onlyOwner {
+    function changeImplementation(address newImplementation) external onlyOwner {
         implementationAddress = newImplementation;
 
         emit ImplementationChanged(newImplementation);
@@ -184,16 +181,13 @@ contract AccountFactory is Ownable {
      * @param salt bytes32 - Salt to be used for the account creation
      * @return accountAddress address - Address of the Clave account that would be created with the given salt
      */
-    function getAddressForSalt(
-        bytes32 salt
-    ) external view returns (address accountAddress) {
-        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT)
-            .getNewAddressCreate2(
-                address(this),
-                proxyBytecodeHash,
-                salt,
-                abi.encode(implementationAddress)
-            );
+    function getAddressForSalt(bytes32 salt) external view returns (address accountAddress) {
+        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).getNewAddressCreate2(
+            address(this),
+            proxyBytecodeHash,
+            salt,
+            abi.encode(implementationAddress)
+        );
     }
 
     /**
@@ -206,12 +200,11 @@ contract AccountFactory is Ownable {
         bytes32 salt,
         address _implementation
     ) external view returns (address accountAddress) {
-        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT)
-            .getNewAddressCreate2(
-                address(this),
-                proxyBytecodeHash,
-                salt,
-                abi.encode(_implementation)
-            );
+        accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).getNewAddressCreate2(
+            address(this),
+            proxyBytecodeHash,
+            salt,
+            abi.encode(_implementation)
+        );
     }
 }

--- a/contracts/validators/EOAValidator.sol
+++ b/contracts/validators/EOAValidator.sol
@@ -29,7 +29,9 @@ contract EOAValidator is IK1Validator, EIP712 {
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure override returns (bool) {
         return
             interfaceId == type(IK1Validator).interfaceId ||
             interfaceId == type(IERC165).interfaceId;

--- a/contracts/validators/EOAValidator.sol
+++ b/contracts/validators/EOAValidator.sol
@@ -2,30 +2,21 @@
 pragma solidity ^0.8.17;
 
 import {IK1Validator, IERC165} from "../interfaces/IValidator.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-contract EOAValidator is IK1Validator {
+contract EOAValidator is IK1Validator, EIP712 {
     using ECDSA for bytes32;
-
-    bytes32 private constant EIP712DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId)");
 
     bytes32 private constant SIGN_MESSAGE_TYPEHASH =
         keccak256("SignMessage(string details,bytes32 hash)");
+
+    constructor() EIP712("zkSync", "2") {}
 
     function validateSignature(
         bytes32 signedTxHash,
         bytes calldata signature
     ) external view returns (address signer) {
-        bytes32 domainSeparator = keccak256(
-            abi.encode(
-                EIP712DOMAIN_TYPEHASH,
-                keccak256(bytes("zkSync")),
-                keccak256(bytes("2")),
-                block.chainid
-            )
-        );
-
         bytes32 structHash = keccak256(
             abi.encode(
                 SIGN_MESSAGE_TYPEHASH,
@@ -33,18 +24,12 @@ contract EOAValidator is IK1Validator {
                 signedTxHash
             )
         );
-
-        bytes32 messageHash = keccak256(
-            abi.encodePacked("\x19\x01", domainSeparator, structHash)
-        );
-
-        signer = ECDSA.recover(messageHash, signature);
+        bytes32 signedMessageHash = _hashTypedDataV4(structHash);
+        signer = ECDSA.recover(signedMessageHash, signature);
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) external pure override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return
             interfaceId == type(IK1Validator).interfaceId ||
             interfaceId == type(IERC165).interfaceId;

--- a/contracts/validators/EOAValidator.sol
+++ b/contracts/validators/EOAValidator.sol
@@ -39,7 +39,6 @@ contract EOAValidator is IK1Validator {
         );
 
         signer = ECDSA.recover(messageHash, signature);
-        require(signer != address(0), "EOAValidator: invalid signature");
     }
 
     /// @inheritdoc IERC165

--- a/contracts/validators/EOAValidator.sol
+++ b/contracts/validators/EOAValidator.sol
@@ -1,31 +1,54 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-import {IK1Validator, IERC165} from '../interfaces/IValidator.sol';
-import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import {IK1Validator, IERC165} from "../interfaces/IValidator.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-/**
- * @title secp256k1 ec keys' signature validator contract implementing its interface
- * @author https://getclave.io
- */
 contract EOAValidator is IK1Validator {
-    // ECDSA library to make verifications
     using ECDSA for bytes32;
 
-    /// @inheritdoc IK1Validator
-    function validateSignature(
-        bytes32 eip712Hash,
-        bytes calldata signature
-    ) external pure override returns (address signer) {
-        bytes32 ethSignedMessageHash = keccak256(
-            abi.encodePacked("\x19Ethereum Signed Message:\n32", eip712Hash)
+    bytes32 private constant EIP712DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId)");
+
+    bytes32 private constant SIGN_MESSAGE_TYPEHASH =
+        keccak256("SignMessage(string details,bytes32 hash)");
+
+    bytes32 private immutable DOMAIN_SEPARATOR;
+
+    constructor() {
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256(bytes("zkSync")),
+                keccak256(bytes("2")),
+                block.chainid
+            )
         );
-        // Recover the signer
-        signer = ethSignedMessageHash.recover(signature);
     }
 
-    /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+    function validateSignature(
+        bytes32 signedTxHash,
+        bytes calldata signature
+    ) external view returns (address signer) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SIGN_MESSAGE_TYPEHASH,
+                keccak256(bytes("You are signing a hash of your transaction")),
+                signedTxHash
+            )
+        );
+
+        bytes32 messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+
+        signer = ECDSA.recover(messageHash, signature);
+        require(signer != address(0), "EOAValidator: invalid signature");
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure override returns (bool) {
         return
             interfaceId == type(IK1Validator).interfaceId ||
             interfaceId == type(IERC165).interfaceId;

--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -42,12 +42,12 @@ export default async function (): Promise<void> {
 
     batchCaller = await deployContract(hre, 'BatchCaller', undefined, {
         wallet: fundingWallet,
-        silent: true,
+        silent: false,
     });
 
     eoaValidator = await deployContract(hre, 'EOAValidator', undefined, {
         wallet: fundingWallet,
-        silent: true,
+        silent: false,
     });
 
     implementation = await deployContract(
@@ -56,22 +56,14 @@ export default async function (): Promise<void> {
         [await batchCaller.getAddress()],
         {
             wallet: fundingWallet,
-            silent: true,
+            silent: false,
         },
     );
 
     registry = await deployContract(hre, 'ClaveRegistry', undefined, {
         wallet: fundingWallet,
-        silent: true,
+        silent: false,
     });
-
-    // //TODO: WHY DOES THIS HELP
-    // await deployContract(
-    //     hre,
-    //     'ClaveProxy',
-    //     [await implementation.getAddress()],
-    //     { wallet: fundingWallet, silent: true },
-    // );
 
     const accountProxyArtifact = await hre.zksyncEthers.loadArtifact('ClaveProxy');
     const bytecodeHash = utils.hashBytecode(accountProxyArtifact.bytecode);
@@ -86,7 +78,7 @@ export default async function (): Promise<void> {
         ],
         {
             wallet: fundingWallet,
-            silent: true,
+            silent: false,
         },
     );
     await registry.setFactory(await factory.getAddress());

--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -65,6 +65,14 @@ export default async function (): Promise<void> {
         silent: false,
     });
 
+    // Need this so the ClaveProxy artifact is valid
+    await deployContract(
+        hre,
+        'ClaveProxy',
+        [await implementation.getAddress()],
+        { wallet: fundingWallet, silent: true, noVerify: true },
+    );
+
     const accountProxyArtifact = await hre.zksyncEthers.loadArtifact('ClaveProxy');
     const bytecodeHash = utils.hashBytecode(accountProxyArtifact.bytecode);
     factory = await deployContract(

--- a/test/utils/p256.ts
+++ b/test/utils/p256.ts
@@ -39,7 +39,7 @@ export function encodePublicKeyK1(key: elliptic.ec.KeyPair): string {
     return address;
 }
 
-export async function sign(msg: string, key: elliptic.ec.KeyPair): Promise<string> {
+export async function sign(msg: string, key: elliptic.ec.KeyPair, chainId: bigint, validatorAddress: string): Promise<string> {
     if (isSecp256k1(key.ec.curve)) {
         const privateKey = padToHex(key.getPrivate().toString(16), 64);
         const wallet = new ethers.Wallet(privateKey);
@@ -49,7 +49,8 @@ export async function sign(msg: string, key: elliptic.ec.KeyPair): Promise<strin
         const domain = {
             name: 'zkSync',
             version: '2',
-            chainId: "260",
+            chainId: chainId.toString(),
+            verifyingContract: validatorAddress,
         };
         
         const types = {

--- a/test/utils/p256.ts
+++ b/test/utils/p256.ts
@@ -39,27 +39,33 @@ export function encodePublicKeyK1(key: elliptic.ec.KeyPair): string {
     return address;
 }
 
-export function sign(msg: string, key: elliptic.ec.KeyPair): string {
+export async function sign(msg: string, key: elliptic.ec.KeyPair): Promise<string> {
     if (isSecp256k1(key.ec.curve)) {
-        // For secp256k1, use ethers.js for EIP-191 signing
         const privateKey = padToHex(key.getPrivate().toString(16), 64);
         const wallet = new ethers.Wallet(privateKey);
         
-        // Remove '0x' prefix if present
-        const cleanMsg = msg.startsWith('0x') ? msg.slice(2) : msg;
+        const signedTxHash = msg.startsWith('0x') ? msg : '0x' + msg;
         
-        // Sign the message using ethers.js v6 (this applies EIP-191 automatically)
-        const signature = wallet.signMessageSync(ethers.getBytes('0x' + cleanMsg));
+        const domain = {
+            name: 'zkSync',
+            version: '2',
+            chainId: "260",
+        };
         
-        // Split the signature
-        const { r, s, v } = ethers.Signature.from(signature);
+        const types = {
+            SignMessage: [
+                { name: 'details', type: 'string' },
+                { name: 'hash', type: 'bytes32' }
+            ]
+        };
         
-        // Format the signature parts
-        const rHex = padToHex(r.slice(2), 64);  // remove '0x' and pad
-        const sHex = padToHex(s.slice(2), 64);  // remove '0x' and pad
-        const vHex = padToHex(v.toString(16), 2);
+        const value = {
+            details: "You are signing a hash of your transaction",
+            hash: signedTxHash
+        };
         
-        return `0x${rHex}${sHex}${vHex}`;
+        // Sign the typed data
+        return await wallet.signTypedData(domain, types, value);
     } else {
         // For non-secp256k1, directly sign the message
         const signatureBuffer = Buffer.from(msg.slice(2), 'hex');

--- a/test/utils/transaction.ts
+++ b/test/utils/transaction.ts
@@ -83,9 +83,9 @@ export async function prepareTeeTx(
 
     const signedTxHash = EIP712Signer.getSignedDigest(tx);
 
-    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
-    let signature = sign(signedTxHash.toString(), keyPair);
+    let signature = await sign(signedTxHash.toString(), keyPair);
 
+    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
     signature = abiCoder.encode(
         ['bytes', 'address', 'bytes[]'],
         [signature, validatorAddress, hookData],
@@ -139,7 +139,7 @@ export async function prepareBatchTx(
 
     const signedTxHash = EIP712Signer.getSignedDigest(tx);
 
-    let signature = sign(signedTxHash.toString(), keyPair);
+    let signature = await sign(signedTxHash.toString(), keyPair);
 
     signature = abiCoder.encode(
         ['bytes', 'address', 'bytes[]'],

--- a/test/utils/transaction.ts
+++ b/test/utils/transaction.ts
@@ -67,13 +67,14 @@ export async function prepareTeeTx(
         tx.value = parseEther('0');
     }
 
+    const chainId = (await provider.getNetwork()).chainId;
     tx = {
         ...tx,
         from: await account.getAddress(),
         nonce: await provider.getTransactionCount(await account.getAddress()),
         gasLimit: 30_000_000,
         gasPrice: await provider.getGasPrice(),
-        chainId: (await provider.getNetwork()).chainId,
+        chainId: chainId,
         type: 113,
         customData: {
             gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
@@ -83,7 +84,7 @@ export async function prepareTeeTx(
 
     const signedTxHash = EIP712Signer.getSignedDigest(tx);
 
-    let signature = await sign(signedTxHash.toString(), keyPair);
+    let signature = await sign(signedTxHash.toString(), keyPair, chainId, validatorAddress);
 
     const abiCoder = ethers.AbiCoder.defaultAbiCoder();
     signature = abiCoder.encode(
@@ -121,6 +122,7 @@ export async function prepareBatchTx(
             )
             .slice(2);
 
+    const chainId = (await provider.getNetwork()).chainId;
     const tx = {
         to: BatchCallerAddress,
         from: await account.getAddress(),
@@ -129,7 +131,7 @@ export async function prepareBatchTx(
         gasPrice: await provider.getGasPrice(),
         data,
         value: parseEther('0'),
-        chainId: (await provider.getNetwork()).chainId,
+        chainId: chainId,
         type: 113,
         customData: {
             gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
@@ -139,7 +141,7 @@ export async function prepareBatchTx(
 
     const signedTxHash = EIP712Signer.getSignedDigest(tx);
 
-    let signature = await sign(signedTxHash.toString(), keyPair);
+    let signature = await sign(signedTxHash.toString(), keyPair, chainId, validatorAddress);
 
     signature = abiCoder.encode(
         ['bytes', 'address', 'bytes[]'],


### PR DESCRIPTION
Rather than have the user sign a raw hash, we'll make them sign an EIP712-encoded payload