### PR TITLE
Audit Fixes

### DIFF
--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import {DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
 import {SystemContractsCaller} from '@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol';
-import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+import {Ownable, Ownable2Step} from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import {Errors} from './libraries/Errors.sol';
 import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
@@ -12,7 +12,7 @@ import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
  * @title Factory contract to create Clave accounts in zkSync Era
  * @author https://getclave.io
  */
-contract AccountFactory is Ownable {
+contract AccountFactory is Ownable2Step {
     // Address of the account implementation 
     address public implementationAddress;
     // Selector of the account initializer function

--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -90,7 +90,7 @@ contract AccountFactory is Ownable {
     function deployAccount(
         bytes32 salt,
         bytes memory initializer
-    ) external returns (address accountAddress) {
+    ) external payable returns (address accountAddress) {
         // Check that the initializer is not empty
         if (initializer.length < 4) {
             revert Errors.INVALID_INITIALIZER();
@@ -137,7 +137,7 @@ contract AccountFactory is Ownable {
             initializeSuccess := call(
                 gas(),
                 accountAddress,
-                0,
+                callvalue(),
                 add(initializer, 0x20),
                 mload(initializer),
                 0,

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -234,11 +234,6 @@ contract ClaveImplementation is
         bytes32 signedHash,
         Transaction calldata transaction
     ) internal returns (bytes4 magicValue) {
-        if (transaction.signature.length == 65) {
-            // This is a gas estimation
-            return bytes4(0);
-        }
-
         // Extract the signature, validator address and hook data from the transaction.signature
         (bytes memory signature, address validator, bytes[] memory hookData) = SignatureDecoder
             .decodeSignature(transaction.signature);

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -246,13 +246,10 @@ contract ClaveImplementation is
         // Run validation hooks
         bool hookSuccess = runValidationHooks(signedHash, transaction, hookData);
 
-        if (!hookSuccess) {
-            return bytes4(0);
-        }
-
+        // Handle validation
         bool valid = _handleValidation(validator, signedHash, signature);
 
-        magicValue = valid ? ACCOUNT_VALIDATION_SUCCESS_MAGIC : bytes4(0);
+        magicValue = (hookSuccess && valid) ? ACCOUNT_VALIDATION_SUCCESS_MAGIC : bytes4(0);
     }
 
     function _executeTransaction(

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -96,8 +96,13 @@ contract ClaveImplementation is
         }
     }
 
-    // Receive function to allow ETHs
+    // Receive function to allow ETH to be sent to the account
+    // with no additional calldata
     receive() external payable {}
+    
+    // Fallback function to allow ETH to be sent to the account
+    // with arbitrary calldata to mirror the behavior of an EOA
+    fallback() external payable {}
 
     /**
      * @notice Called by the bootloader to validate that an account agrees to process the transaction

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -64,7 +64,7 @@ contract ClaveImplementation is
         address initialK1Validator,
         bytes[] calldata modules,
         Call calldata initCall
-    ) public initializer {
+    ) public payable initializer {
         __ERC1271Handler_init();
         // check that this account is being deployed by the initial signer or the factory authorized deployer
         AccountFactory factory = AccountFactory(msg.sender);

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -68,6 +68,11 @@ contract ClaveImplementation is
         __ERC1271Handler_init();
         // check that this account is being deployed by the initial signer or the factory authorized deployer
         AccountFactory factory = AccountFactory(msg.sender);
+        // require a specific salt for the acccount based on the initial k1 owner
+        address expectedAddress = factory.getAddressForSalt(keccak256(abi.encodePacked(initialK1Owner)));
+        if (address(this) != expectedAddress) {
+            revert Errors.INVALID_SALT();
+        }
         address thisDeployer = factory.accountToDeployer(address(this));
         if (thisDeployer != factory.deployer()) {
             if (initialK1Owner != thisDeployer) {

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -182,6 +182,7 @@ contract ClaveImplementation is
             revert Errors.VALIDATION_HOOK_FAILED();
         }
 
+        _incrementNonce(transaction.nonce);
         _executeTransaction(transaction);
     }
 

--- a/contracts/ClaveImplementation.sol
+++ b/contracts/ClaveImplementation.sol
@@ -102,7 +102,21 @@ contract ClaveImplementation is
     
     // Fallback function to allow ETH to be sent to the account
     // with arbitrary calldata to mirror the behavior of an EOA
-    fallback() external payable {}
+    fallback() external payable {
+        // Simulate the behavior of the EOA if it is called via `delegatecall`.
+        address codeAddress = SystemContractHelper.getCodeAddress();
+        if (codeAddress != address(this)) {
+            // If the function was delegate called, behave like an EOA.
+            assembly {
+                return(0, 0)
+            }
+        }
+
+        // fallback of default account shouldn't be called by bootloader under any circumstances
+        assert(msg.sender != BOOTLOADER_FORMAL_ADDRESS);
+
+        // If the contract is called directly, behave like an EOA
+    }
 
     /**
      * @notice Called by the bootloader to validate that an account agrees to process the transaction

--- a/contracts/ClaveRegistry.sol
+++ b/contracts/ClaveRegistry.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+import {Ownable, Ownable2Step} from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import {Errors} from './libraries/Errors.sol';
 import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
 
-contract ClaveRegistry is Ownable, IClaveRegistry {
+contract ClaveRegistry is Ownable2Step, IClaveRegistry {
     mapping(address => bool) public isFactory;
     // Mapping of Clave accounts
     mapping(address => bool) public isClave;

--- a/contracts/handlers/ValidationHandler.sol
+++ b/contracts/handlers/ValidationHandler.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {SignatureDecoder} from '../libraries/SignatureDecoder.sol';
-import {BytesLinkedList} from '../libraries/LinkedList.sol';
+import {BytesLinkedList, AddressLinkedList} from '../libraries/LinkedList.sol';
 import {OwnerManager} from '../managers/OwnerManager.sol';
 import {ValidatorManager} from '../managers/ValidatorManager.sol';
 
@@ -19,7 +19,11 @@ abstract contract ValidationHandler is OwnerManager, ValidatorManager {
         bytes32 signedHash,
         bytes memory signature
     ) internal view returns (bool) {
-        if (_r1IsValidator(validator)) {
+        if (validator <= AddressLinkedList.SENTINEL_ADDRESS) {
+            // address less than or equal to sentinel address can't be used in linked list
+            // implementation so this scenario is never valid
+            return false;
+        } else if (_r1IsValidator(validator)) {
             mapping(bytes => bytes) storage owners = OwnerManager._r1OwnersLinkedList();
             bytes memory cursor = owners[BytesLinkedList.SENTINEL_BYTES];
             while (cursor.length > BytesLinkedList.SENTINEL_LENGTH) {

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -100,6 +100,8 @@ library Errors {
 
     error DEPLOYMENT_FAILED();
     error INITIALIZATION_FAILED();
+    error INVALID_INITIALIZER();
+    error INVALID_SALT();
 
     /*//////////////////////////////////////////////////////////////
                             PAYMASTER

--- a/contracts/managers/HookManager.sol
+++ b/contracts/managers/HookManager.sol
@@ -171,6 +171,11 @@ abstract contract HookManager is IHookManager, Auth {
         } else {
             _executionHooksLinkedList().remove(hook);
         }
+        
+        // if the hook removal occured during execution of hooks, the hook 
+        // context will not be cleaned up during post execution so we need
+        // to delete it manually
+        _deleteContext(hook);
 
         (bool success, ) = hook.excessivelySafeCall(
             gasleft(),

--- a/contracts/managers/HookManager.sol
+++ b/contracts/managers/HookManager.sol
@@ -85,6 +85,11 @@ abstract contract HookManager is IHookManager, Auth {
         uint256 idx = 0;
         // Iterate through hooks
         while (cursor > AddressLinkedList.SENTINEL_ADDRESS) {
+            // hookData array is out of bounds for the number of hooks
+            if (idx >= hookData.length) {
+                return false;
+            }
+
             // Call it with corresponding hookData
             bool success = _call(
                 cursor,

--- a/contracts/managers/OwnerManager.sol
+++ b/contracts/managers/OwnerManager.sol
@@ -91,13 +91,6 @@ abstract contract OwnerManager is IOwnerManager, Auth {
     function _r1RemoveOwner(bytes calldata pubKey) internal {
         _r1OwnersLinkedList().remove(pubKey);
 
-        // The wallet should have at least one owner
-        if (
-            _k1OwnersLinkedList().isEmpty() && _r1OwnersLinkedList().isEmpty()
-        ) {
-            revert Errors.EMPTY_OWNERS();
-        }
-
         emit R1RemoveOwner(pubKey);
     }
 
@@ -105,9 +98,7 @@ abstract contract OwnerManager is IOwnerManager, Auth {
         _k1OwnersLinkedList().remove(addr);
 
         // The wallet should have at least one owner
-        if (
-            _k1OwnersLinkedList().isEmpty() && _r1OwnersLinkedList().isEmpty()
-        ) {
+        if (_k1OwnersLinkedList().isEmpty()) {
             revert Errors.EMPTY_OWNERS();
         }
 

--- a/contracts/managers/ValidatorManager.sol
+++ b/contracts/managers/ValidatorManager.sol
@@ -85,14 +85,6 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
     function _r1RemoveValidator(address validator) internal {
         _r1ValidatorsLinkedList().remove(validator);
 
-        // At least one validator must be present
-        if (
-            _r1ValidatorsLinkedList().isEmpty() &&
-            _k1ValidatorsLinkedList().isEmpty()
-        ) {
-            revert Errors.EMPTY_VALIDATORS();
-        }
-
         emit R1RemoveValidator(validator);
     }
 
@@ -100,10 +92,7 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
         _k1ValidatorsLinkedList().remove(validator);
 
         // At least one validator must be present
-        if (
-            _r1ValidatorsLinkedList().isEmpty() &&
-            _k1ValidatorsLinkedList().isEmpty()
-        ) {
+        if (_k1ValidatorsLinkedList().isEmpty()) {
             revert Errors.EMPTY_VALIDATORS();
         }
 

--- a/test/deployments/deployer.test.ts
+++ b/test/deployments/deployer.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import type { ec } from 'elliptic';
 import type { BytesLike, HDNodeWallet } from 'ethers';
-import { parseEther } from 'ethers';
+import { hexlify, parseEther, randomBytes } from 'ethers';
 import * as hre from 'hardhat';
 import type { Contract, Wallet } from 'zksync-ethers';
 import { Provider } from 'zksync-ethers';
@@ -103,6 +103,22 @@ describe('Clave Contracts - Deployer class tests', () => {
 
             expect(await registry.isClave(accountAddress)).to.be.true;
             expect(await registry.isClave(factoryAddress)).not.to.be.true;
+        });
+
+        it('should not deploy an account with an invalid salt', async () => {
+            const salt = randomBytes(32);
+            await expect(deployer.account(wallet, factory, eoaValidator, hexlify(salt)))
+                .to.be.revertedWithCustomError(factory, "INITIALIZATION_FAILED");
+        });
+
+        it('should not deploy an account with an empty initializer', async () => {
+            await expect(deployer.account(wallet, factory, eoaValidator, undefined, '0x'))
+            .to.be.revertedWithCustomError(factory, "INVALID_INITIALIZER");
+        });
+
+        it('should not deploy an account with an invalid initializer selector', async () => {
+            await expect(deployer.account(wallet, factory, eoaValidator, undefined, '0xabababab'))
+            .to.be.revertedWithCustomError(factory, "INVALID_INITIALIZER");
         });
     });
 });


### PR DESCRIPTION
- **[TRST-M-1][M-05]: Require specific deployment salt and initializer selector for account deployment**
- **[M-04] make initial call payable**
- **[M-02] - clean up hook contet when removing hook**
- **[L-05] Use Ownable2Step**
- **[L-04] - Return false instead of reverting for invalid validator address**
- **[L-03] return false from `runValidationHooks` if hook data length is lower than the number of hooks being executed**
- **[L-01] add fallback function**
- **[H-01] increment nonce on executeTransactionFromOutside**
- **[M-03] remove early return and check hookSuccess at the end of validation**
- **[TRST-L-01] Ensure at least one K1 validator and owner are always present**
