### PR TITLE
Rename contracts and function to be 'AGW' instead of 'Clave'

### DIFF
--- a/contracts/AGWAccount.sol
+++ b/contracts/AGWAccount.sol
@@ -22,16 +22,18 @@ import {SignatureDecoder} from './libraries/SignatureDecoder.sol';
 import {ERC1271Handler} from './handlers/ERC1271Handler.sol';
 import {Call} from './batch/BatchCaller.sol';
 
-import {IClaveAccount} from './interfaces/IClave.sol';
+import {IAGWAccount} from './interfaces/IAGWAccount.sol';
 import {AccountFactory} from './AccountFactory.sol';
 import {BatchCaller} from './batch/BatchCaller.sol';
 
 /**
- * @title Main account contract for the Clave wallet infrastructure, forked for Abstract
+ * @title Main account contract for the Abstract Global Wallet infrastructure
+ * @dev Forked from Clave for Abstract
  * @dev The Abstract fork uses a K1 signer and validator initially
  * @author https://getclave.io
+ * @author https://abs.xyz
  */
-contract ClaveImplementation is
+contract AGWAccount is
     Initializable,
     UpgradeManager,
     HookManager,
@@ -39,7 +41,7 @@ contract ClaveImplementation is
     ERC1271Handler,
     TokenCallbackHandler,
     BatchCaller,
-    IClaveAccount
+    IAGWAccount
 {
     // Helper library for the Transaction struct
     using TransactionHelper for Transaction;
@@ -237,12 +239,12 @@ contract ClaveImplementation is
         transaction.processPaymasterInput();
     }
 
-    /// @dev type(IClave).interfaceId indicates Clave accounts
+    /// @dev type(IAGWAccount).interfaceId indicates AGW accounts
     function supportsInterface(
         bytes4 interfaceId
     ) public view override(IERC165, TokenCallbackHandler) returns (bool) {
         return
-            interfaceId == type(IClaveAccount).interfaceId || super.supportsInterface(interfaceId);
+            interfaceId == type(IAGWAccount).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _validateTransaction(

--- a/contracts/AGWRegistry.sol
+++ b/contracts/AGWRegistry.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.17;
 import {Ownable, Ownable2Step} from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import {Errors} from './libraries/Errors.sol';
-import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
+import {IAGWRegistry} from './interfaces/IAGWRegistry.sol';
 
-contract ClaveRegistry is Ownable2Step, IClaveRegistry {
+contract AGWRegistry is Ownable2Step, IAGWRegistry {
     mapping(address => bool) public isFactory;
-    // Mapping of Clave accounts
-    mapping(address => bool) public isClave;
+    // Mapping of AGW accounts
+    mapping(address => bool) public isAGW;
 
     /**
      * @notice Event emmited when a factory contract is set
@@ -27,7 +27,7 @@ contract ClaveRegistry is Ownable2Step, IClaveRegistry {
     constructor(address _owner) Ownable(_owner) {}
 
     /**
-     * @notice Registers an account as a Clave account
+     * @notice Registers an account as a AGW account
      * @dev Can only be called by the factory or owner
      * @param account address - Address of the account to register
      */
@@ -36,11 +36,11 @@ contract ClaveRegistry is Ownable2Step, IClaveRegistry {
             revert Errors.NOT_FROM_FACTORY();
         }
 
-        isClave[account] = true;
+        isAGW[account] = true;
     }
 
     /**
-     * @notice Registers multiple accounts as Clave accounts
+     * @notice Registers multiple accounts as AGW accounts
      * @dev Can only be called by the factory or owner
      * @param accounts address[] - Array of addresses to register
      */
@@ -50,12 +50,12 @@ contract ClaveRegistry is Ownable2Step, IClaveRegistry {
         }
 
         for (uint256 i = 0; i < accounts.length; i++) {
-            isClave[accounts[i]] = true;
+            isAGW[accounts[i]] = true;
         }
     }
 
     /**
-     * @notice Unregisters an account as a Clave account
+     * @notice Unregisters an account as a AGW account
      * @dev Can only be called by the factory or owner
      * @param account address - Address of the account to unregister
      */
@@ -64,11 +64,11 @@ contract ClaveRegistry is Ownable2Step, IClaveRegistry {
             revert Errors.NOT_FROM_FACTORY();
         }
 
-        isClave[account] = false;
+        isAGW[account] = false;
     }
 
     /**
-     * @notice Unregisters multiple accounts as Clave accounts
+     * @notice Unregisters multiple accounts as AGW accounts
      * @dev Can only be called by the factory or owner
      * @param accounts address[] - Array of addresses to unregister
      */
@@ -78,7 +78,7 @@ contract ClaveRegistry is Ownable2Step, IClaveRegistry {
         }
 
         for (uint256 i = 0; i < accounts.length; i++) {
-            isClave[accounts[i]] = false;
+            isAGW[accounts[i]] = false;
         }
     }
 

--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -6,10 +6,12 @@ import {SystemContractsCaller} from '@matterlabs/zksync-contracts/l2/system-cont
 import {Ownable, Ownable2Step} from '@openzeppelin/contracts/access/Ownable2Step.sol';
 
 import {Errors} from './libraries/Errors.sol';
-import {IClaveRegistry} from './interfaces/IClaveRegistry.sol';
+import {IAGWRegistry} from './interfaces/IAGWRegistry.sol';
 
 /**
- * @title Factory contract to create Clave accounts in zkSync Era
+ * @title Factory contract to create AGW accounts
+ * @dev Forked from Clave for Abstract
+ * @author https://abs.xyz
  * @author https://getclave.io
  */
 contract AccountFactory is Ownable2Step {
@@ -23,22 +25,22 @@ contract AccountFactory is Ownable2Step {
 
     // Account creation bytecode hash
     bytes32 public proxyBytecodeHash;
-    // Account authorized to deploy Clave accounts
+    // Account authorized to deploy AGW accounts
     address public deployer;
     // Mapping to store the deployer of each account
     mapping (address => address) public accountToDeployer;
 
     /**
-     * @notice Event emmited when a new Clave account is created
-     * @param accountAddress Address of the newly created Clave account
+     * @notice Event emmited when a new AGW account is created
+     * @param accountAddress Address of the newly created AGW account
      */
-    event ClaveAccountCreated(address indexed accountAddress);
+    event AGWAccountCreated(address indexed accountAddress);
 
     /**
-     * @notice Event emmited when a new Clave account is deployed
-     * @param accountAddress Address of the newly deployed Clave account
+     * @notice Event emmited when a new AGW account is deployed
+     * @param accountAddress Address of the newly deployed AGW account
      */
-    event ClaveAccountDeployed(address indexed accountAddress);
+    event AGWAccountDeployed(address indexed accountAddress);
 
     /**
      * @notice Event emmited when the deployer account is changed
@@ -62,8 +64,8 @@ contract AccountFactory is Ownable2Step {
      * @notice Constructor function of the factory contract
      * @param _implementation address     - Address of the implementation contract
      * @param _registry address           - Address of the registry contract
-     * @param _proxyBytecodeHash address - Hash of the bytecode of the clave proxy contract
-     * @param _deployer address           - Address of the account authorized to deploy Clave accounts
+     * @param _proxyBytecodeHash address - Hash of the bytecode of the AGW proxy contract
+     * @param _deployer address           - Address of the account authorized to deploy AGW accounts
      */
     constructor(
         address _implementation,
@@ -81,11 +83,11 @@ contract AccountFactory is Ownable2Step {
     }
 
     /**
-     * @notice Deploys a new Clave account
+     * @notice Deploys a new AGW account
      * @dev Account address depends only on salt
      * @param salt bytes32             - Salt to be used for the account creation
      * @param initializer bytes memory - Initializer data for the account
-     * @return accountAddress address - Address of the newly created Clave account
+     * @return accountAddress address - Address of the newly created AGW account
      */
     function deployAccount(
         bytes32 salt,
@@ -149,26 +151,26 @@ contract AccountFactory is Ownable2Step {
             revert Errors.INITIALIZATION_FAILED();
         }
 
-        IClaveRegistry(registry).register(accountAddress);
+        IAGWRegistry(registry).register(accountAddress);
 
-        emit ClaveAccountDeployed(accountAddress);
+        emit AGWAccountDeployed(accountAddress);
     }
 
     /**
-     * @notice To emit an event when a Clave account is created but not yet deployed
+     * @notice To emit an event when a AGW account is created but not yet deployed
      * @dev This event is so that we can index accounts that are created but not yet deployed
-     * @param accountAddress address - Address of the Clave account that was created
+     * @param accountAddress address - Address of the AGW account that was created
      */
-    function claveAccountCreated(address accountAddress) external {
+    function agwAccountCreated(address accountAddress) external {
         if (msg.sender != deployer) {
             revert Errors.NOT_FROM_DEPLOYER();
         }
-        emit ClaveAccountCreated(accountAddress);
+        emit AGWAccountCreated(accountAddress);
     }
 
     /**
-     * @notice Changes the account authorized to deploy Clave accounts
-     * @param newDeployer address - Address of the new account authorized to deploy Clave accounts
+     * @notice Changes the account authorized to deploy AGW accounts
+     * @param newDeployer address - Address of the new account authorized to deploy AGW accounts
      */
     function changeDeployer(address newDeployer) external onlyOwner {
         deployer = newDeployer;
@@ -198,9 +200,9 @@ contract AccountFactory is Ownable2Step {
     }
 
     /**
-     * @notice Returns the address of the Clave account that would be created with the given salt
+     * @notice Returns the address of the AGW account that would be created with the given salt
      * @param salt bytes32 - Salt to be used for the account creation
-     * @return accountAddress address - Address of the Clave account that would be created with the given salt
+     * @return accountAddress address - Address of the AGW account that would be created with the given salt
      */
     function getAddressForSalt(bytes32 salt) external view returns (address accountAddress) {
         accountAddress = IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).getNewAddressCreate2(
@@ -212,10 +214,10 @@ contract AccountFactory is Ownable2Step {
     }
 
     /**
-     * @notice Returns the address of the Clave account that would be created with the given salt and implementation
+     * @notice Returns the address of the AGW account that would be created with the given salt and implementation
      * @param salt bytes32 - Salt to be used for the account creation
      * @param _implementation address - Address of the implementation contract
-     * @return accountAddress address - Address of the Clave account that would be created with the given salt and implementation
+     * @return accountAddress address - Address of the AGW account that would be created with the given salt and implementation
      */
     function getAddressForSaltAndImplementation(
         bytes32 salt,

--- a/contracts/AccountProxy.sol
+++ b/contracts/AccountProxy.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import {EfficientCall} from '@matterlabs/zksync-contracts/l2/system-contracts/libraries/EfficientCall.sol';
 
-contract ClaveProxy {
+contract AccountProxy {
     event Upgraded(address indexed implementation);
 
     //keccak-256 of "eip1967.proxy.implementation" subtracted by 1

--- a/contracts/handlers/ERC1271Handler.sol
+++ b/contracts/handlers/ERC1271Handler.sol
@@ -10,18 +10,20 @@ import {EIP712Upgradeable} from '@openzeppelin/contracts-upgradeable/utils/crypt
 /**
  * @title ERC1271Handler
  * @notice Contract which provides ERC1271 signature validation
+ * @dev Forked from Clave for Abstract
  * @author https://getclave.io
+ * @author https://abs.xyz
  */
 abstract contract ERC1271Handler is
     IERC1271,
     EIP712Upgradeable,
     ValidationHandler
 {
-    struct ClaveMessage {
+    struct AGWMessage {
         bytes32 signedHash;
     }
 
-    bytes32 constant _CLAVE_MESSAGE_TYPEHASH = keccak256('ClaveMessage(bytes32 signedHash)');
+    bytes32 constant _AGW_MESSAGE_TYPEHASH = keccak256('AGWMessage(bytes32 signedHash)');
 
     bytes4 private constant _ERC1271_MAGIC = 0x1626ba7e;
 
@@ -43,7 +45,7 @@ abstract contract ERC1271Handler is
             signatureAndValidator
         );
 
-        bytes32 eip712Hash = _hashTypedDataV4(_claveMessageHash(ClaveMessage(signedHash)));
+        bytes32 eip712Hash = _hashTypedDataV4(_agwMessageHash(AGWMessage(signedHash)));
 
         bool valid = _handleValidation(validator, eip712Hash, signature);
 
@@ -51,23 +53,23 @@ abstract contract ERC1271Handler is
     }
 
     /**
-     * @notice Returns the EIP-712 hash of the Clave message
-     * @param claveMessage ClaveMessage calldata - The message containing signedHash
+     * @notice Returns the EIP-712 hash of the AGW message
+     * @param agwMessage AGWMessage calldata - The message containing signedHash
      * @return bytes32 - EIP712 hash of the message
      */
-    function getEip712Hash(ClaveMessage calldata claveMessage) external view returns (bytes32) {
-        return _hashTypedDataV4(_claveMessageHash(claveMessage));
+    function getEip712Hash(AGWMessage calldata agwMessage) external view returns (bytes32) {
+        return _hashTypedDataV4(_agwMessageHash(agwMessage));
     }
 
     /**
-     * @notice Returns the typehash for the clave message struct
-     * @return bytes32 - Clave message typehash
+     * @notice Returns the typehash for the AGW message struct
+     * @return bytes32 - AGW message typehash
      */
-    function claveMessageTypeHash() external pure returns (bytes32) {
-        return _CLAVE_MESSAGE_TYPEHASH;
+    function agwMessageTypeHash() external pure returns (bytes32) {
+        return _AGW_MESSAGE_TYPEHASH;
     }
 
-    function _claveMessageHash(ClaveMessage memory claveMessage) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_CLAVE_MESSAGE_TYPEHASH, claveMessage.signedHash));
+    function _agwMessageHash(AGWMessage memory agwMessage) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_AGW_MESSAGE_TYPEHASH, agwMessage.signedHash));
     }
 }

--- a/contracts/interfaces/IAGWAccount.sol
+++ b/contracts/interfaces/IAGWAccount.sol
@@ -15,11 +15,14 @@ import {IUpgradeManager} from './IUpgradeManager.sol';
 import {IValidatorManager} from './IValidatorManager.sol';
 
 /**
- * @title IClave
- * @notice Interface for the Clave contract
- * @dev Implementations of this interface are contract that can be used as a Clave
+ * @title IAGWAccount
+ * @notice Interface for the AGW contract
+ * @dev Implementations of this interface are contracts that can be used as an AGW account
+ * @dev Forked from Clave for Abstract
+ * @author https://getclave.io
+ * @author https://abs.xyz
  */
-interface IClaveAccount is
+interface IAGWAccount is
     IERC1271,
     IERC721Receiver,
     IERC1155Receiver,

--- a/contracts/interfaces/IAGWRegistry.sol
+++ b/contracts/interfaces/IAGWRegistry.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-interface IClaveRegistry {
+interface IAGWRegistry {
     function register(address account) external;
 
-    function isClave(address account) external view returns (bool);
+    function isAGW(address account) external view returns (bool);
 }

--- a/contracts/libraries/AGWStorage.sol
+++ b/contracts/libraries/AGWStorage.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-library ClaveStorage {
-    //keccak256('clave.contracts.ClaveStorage') - 1
-    bytes32 private constant CLAVE_STORAGE_SLOT =
-        0x3248da1aeae8bd923cbf26901dc4bfc6bb48bb0fbc5b6102f1151fe7012884f4;
+library AGWStorage {
+    //keccak256('agw.contracts.AGWStorage') - 1
+    bytes32 private constant AGW_STORAGE_SLOT =
+        0x67641650ff26a63f6b1fb8b1cb96de5bac5c28fcfcca35c9518ea6966d32d42d;
 
     struct Layout {
         // ┌───────────────────┐
@@ -44,7 +44,7 @@ library ClaveStorage {
     }
 
     function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = CLAVE_STORAGE_SLOT;
+        bytes32 slot = AGW_STORAGE_SLOT;
         assembly {
             l.slot := slot
         }

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 library Errors {
     /*//////////////////////////////////////////////////////////////
-                               CLAVE
+                               AGW
     //////////////////////////////////////////////////////////////*/
 
     error INSUFFICIENT_FUNDS(); // 0xe7931438
@@ -117,7 +117,7 @@ library Errors {
     error INVALID_MARKUP(); // 0x4af7ffe3
     error USER_LIMIT_REACHED(); // 0x07235346
     error INVALID_USER_LIMIT(); // 0x2640fa41
-    error NOT_CLAVE_ACCOUNT(); // 0x81566ee0
+    error NOT_AGW_ACCOUNT(); // 0x1ae1d6fd
     error EXCEEDS_MAX_SPONSORED_ETH(); // 0x3f379f40
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/managers/HookManager.sol
+++ b/contracts/managers/HookManager.sol
@@ -6,7 +6,7 @@ import {Transaction} from '@matterlabs/zksync-contracts/l2/system-contracts/libr
 import {ExcessivelySafeCall} from '@nomad-xyz/excessively-safe-call/src/ExcessivelySafeCall.sol';
 
 import {Auth} from '../auth/Auth.sol';
-import {ClaveStorage} from '../libraries/ClaveStorage.sol';
+import {AGWStorage} from '../libraries/AGWStorage.sol';
 import {AddressLinkedList} from '../libraries/LinkedList.sol';
 import {Errors} from '../libraries/Errors.sol';
 import {IExecutionHook, IValidationHook} from '../interfaces/IHook.sol';
@@ -221,7 +221,7 @@ abstract contract HookManager is IHookManager, Auth {
         view
         returns (mapping(address => address) storage validationHooks)
     {
-        validationHooks = ClaveStorage.layout().validationHooks;
+        validationHooks = AGWStorage.layout().validationHooks;
     }
 
     function _executionHooksLinkedList()
@@ -229,7 +229,7 @@ abstract contract HookManager is IHookManager, Auth {
         view
         returns (mapping(address => address) storage executionHooks)
     {
-        executionHooks = ClaveStorage.layout().executionHooks;
+        executionHooks = AGWStorage.layout().executionHooks;
     }
 
     function _hookDataStore()
@@ -237,7 +237,7 @@ abstract contract HookManager is IHookManager, Auth {
         view
         returns (mapping(address => mapping(bytes32 => bytes)) storage hookDataStore)
     {
-        hookDataStore = ClaveStorage.layout().hookDataStore;
+        hookDataStore = AGWStorage.layout().hookDataStore;
     }
 
     function _supportsHook(address hook, bool isValidation) internal view returns (bool) {

--- a/contracts/managers/ModuleManager.sol
+++ b/contracts/managers/ModuleManager.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.17;
 import {ERC165Checker} from '@openzeppelin/contracts/utils/introspection/ERC165Checker.sol';
 import {ExcessivelySafeCall} from '@nomad-xyz/excessively-safe-call/src/ExcessivelySafeCall.sol';
 
-import {ClaveStorage} from '../libraries/ClaveStorage.sol';
+import {AGWStorage} from '../libraries/AGWStorage.sol';
 import {Auth} from '../auth/Auth.sol';
 import {AddressLinkedList} from '../libraries/LinkedList.sol';
 import {Errors} from '../libraries/Errors.sol';
 import {IModule} from '../interfaces/IModule.sol';
 import {IInitable} from '../interfaces/IInitable.sol';
-import {IClaveAccount} from '../interfaces/IClave.sol';
+import {IAGWAccount} from '../interfaces/IAGWAccount.sol';
 import {IModuleManager} from '../interfaces/IModuleManager.sol';
 
 /**
@@ -106,7 +106,7 @@ abstract contract ModuleManager is IModuleManager, Auth {
         view
         returns (mapping(address => address) storage modules)
     {
-        modules = ClaveStorage.layout().modules;
+        modules = AGWStorage.layout().modules;
     }
 
     function _supportsModule(address module) internal view returns (bool) {

--- a/contracts/managers/OwnerManager.sol
+++ b/contracts/managers/OwnerManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
-import {ClaveStorage} from '../libraries/ClaveStorage.sol';
+import {AGWStorage} from '../libraries/AGWStorage.sol';
 import {BytesLinkedList, AddressLinkedList} from '../libraries/LinkedList.sol';
 import {Errors} from '../libraries/Errors.sol';
 import {Auth} from '../auth/Auth.sol';
-import {IClaveAccount} from '../interfaces/IClave.sol';
+import {IAGWAccount} from '../interfaces/IAGWAccount.sol';
 import {IOwnerManager} from '../interfaces/IOwnerManager.sol';
 
 /**
@@ -118,7 +118,7 @@ abstract contract OwnerManager is IOwnerManager, Auth {
         view
         returns (mapping(bytes => bytes) storage r1Owners)
     {
-        r1Owners = ClaveStorage.layout().r1Owners;
+        r1Owners = AGWStorage.layout().r1Owners;
     }
 
     function _k1OwnersLinkedList()
@@ -126,7 +126,7 @@ abstract contract OwnerManager is IOwnerManager, Auth {
         view
         returns (mapping(address => address) storage k1Owners)
     {
-        k1Owners = ClaveStorage.layout().k1Owners;
+        k1Owners = AGWStorage.layout().k1Owners;
     }
 
     function _r1ClearOwners() private {

--- a/contracts/managers/ValidatorManager.sol
+++ b/contracts/managers/ValidatorManager.sol
@@ -5,7 +5,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 
 import { Auth } from "../auth/Auth.sol";
 import { Errors } from "../libraries/Errors.sol";
-import { ClaveStorage } from "../libraries/ClaveStorage.sol";
+import {AGWStorage} from '../libraries/AGWStorage.sol';
 import { AddressLinkedList } from "../libraries/LinkedList.sol";
 import { IR1Validator, IK1Validator } from "../interfaces/IValidator.sol";
 import { IValidatorManager } from "../interfaces/IValidatorManager.sol";
@@ -165,7 +165,7 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
         view
         returns (mapping(address => address) storage r1Validators)
     {
-        r1Validators = ClaveStorage.layout().r1Validators;
+        r1Validators = AGWStorage.layout().r1Validators;
     }
 
     function _moduleValidatorsLinkedList()
@@ -173,7 +173,7 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
         view
         returns (mapping(address => address) storage moduleValidators)
     {
-        moduleValidators = ClaveStorage.layout().moduleValidators;
+        moduleValidators = AGWStorage.layout().moduleValidators;
     }
 
     function _k1ValidatorsLinkedList()
@@ -181,6 +181,6 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
         view
         returns (mapping(address => address) storage k1Validators)
     {
-        k1Validators = ClaveStorage.layout().k1Validators;
+        k1Validators = AGWStorage.layout().k1Validators;
     }
 }

--- a/contracts/modules/recovery/CloudRecoveryModule.sol
+++ b/contracts/modules/recovery/CloudRecoveryModule.sol
@@ -7,7 +7,7 @@ import {SignatureChecker} from '@openzeppelin/contracts/utils/cryptography/Signa
 import {EIP712} from '@openzeppelin/contracts/utils/cryptography/EIP712.sol';
 import {Errors} from '../../libraries/Errors.sol';
 import {IInitable} from '../../interfaces/IInitable.sol';
-import {IClaveAccount} from '../../interfaces/IClave.sol';
+import {IAGWAccount} from '../../interfaces/IAGWAccount.sol';
 import {BaseRecovery} from './base/BaseRecovery.sol';
 
 /**
@@ -52,7 +52,7 @@ contract CloudRecoveryModule is BaseRecovery {
             revert Errors.ALREADY_INITED();
         }
 
-        if (!IClaveAccount(msg.sender).isModule(address(this))) {
+        if (!IAGWAccount(msg.sender).isModule(address(this))) {
             revert Errors.MODULE_NOT_ADDED_CORRECTLY();
         }
 
@@ -72,7 +72,7 @@ contract CloudRecoveryModule is BaseRecovery {
             revert Errors.RECOVERY_NOT_INITED();
         }
 
-        if (IClaveAccount(msg.sender).isModule(address(this))) {
+        if (IAGWAccount(msg.sender).isModule(address(this))) {
             revert Errors.MODULE_NOT_REMOVED_CORRECTLY();
         }
 

--- a/contracts/modules/recovery/EmailRecoveryModule.sol
+++ b/contracts/modules/recovery/EmailRecoveryModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import {IModule} from '../../interfaces/IModule.sol';
 import {IEmailRecoveryModule} from '../../interfaces/IEmailRecoveryModule.sol';
-import {IClaveAccount} from '../../interfaces/IClave.sol';
+import {IAGWAccount} from '../../interfaces/IAGWAccount.sol';
 import {Errors} from '../../libraries/Errors.sol';
 import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import {EmailRecoveryManager, GuardianManager} from '../../EmailRecoveryManager.sol';
@@ -40,7 +40,7 @@ contract EmailRecoveryModule is EmailRecoveryManager, IModule, IEmailRecoveryMod
             revert Errors.ALREADY_INITED();
         }
 
-        if (!IClaveAccount(msg.sender).isModule(address(this))) {
+        if (!IAGWAccount(msg.sender).isModule(address(this))) {
             revert Errors.MODULE_NOT_ADDED_CORRECTLY();
         }
 
@@ -78,7 +78,7 @@ contract EmailRecoveryModule is EmailRecoveryManager, IModule, IEmailRecoveryMod
     }
 
     function recover(address account, bytes calldata newOwner) internal override {
-        IClaveAccount(account).resetOwners(newOwner);
+        IAGWAccount(account).resetOwners(newOwner);
 
         emit RecoveryExecuted(account, newOwner);
     }

--- a/contracts/modules/recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/recovery/SocialRecoveryModule.sol
@@ -6,7 +6,7 @@ import {SignatureChecker} from '@openzeppelin/contracts/utils/cryptography/Signa
 
 import {EIP712} from '@openzeppelin/contracts/utils/cryptography/EIP712.sol';
 import {Errors} from '../../libraries/Errors.sol';
-import {IClaveAccount} from '../../interfaces/IClave.sol';
+import {IAGWAccount} from '../../interfaces/IAGWAccount.sol';
 import {BaseRecovery} from './base/BaseRecovery.sol';
 
 /**
@@ -65,7 +65,7 @@ contract SocialRecoveryModule is BaseRecovery {
             revert Errors.ALREADY_INITED();
         }
 
-        if (!IClaveAccount(msg.sender).isModule(address(this))) {
+        if (!IAGWAccount(msg.sender).isModule(address(this))) {
             revert Errors.MODULE_NOT_ADDED_CORRECTLY();
         }
 
@@ -85,7 +85,7 @@ contract SocialRecoveryModule is BaseRecovery {
             revert Errors.RECOVERY_NOT_INITED();
         }
 
-        if (IClaveAccount(msg.sender).isModule(address(this))) {
+        if (IAGWAccount(msg.sender).isModule(address(this))) {
             revert Errors.MODULE_NOT_REMOVED_CORRECTLY();
         }
 

--- a/contracts/modules/recovery/base/BaseRecovery.sol
+++ b/contracts/modules/recovery/base/BaseRecovery.sol
@@ -6,7 +6,7 @@ import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import {EIP712} from '@openzeppelin/contracts/utils/cryptography/EIP712.sol';
 import {IModule} from '../../../interfaces/IModule.sol';
 import {Errors} from '../../../libraries/Errors.sol';
-import {IClaveAccount} from '../../../interfaces/IClave.sol';
+import {IAGWAccount} from '../../../interfaces/IAGWAccount.sol';
 
 /**
  * @title Base Account Recovery Module
@@ -83,7 +83,7 @@ abstract contract BaseRecovery is IModule, EIP712 {
             revert Errors.RECOVERY_TIMELOCK();
         }
 
-        IClaveAccount(recoveringAddress).resetOwners(recoveryState.newOwner);
+        IAGWAccount(recoveringAddress).resetOwners(recoveryState.newOwner);
 
         delete recoveryStates[recoveringAddress];
 

--- a/contracts/paymasters/GaslessPaymaster.sol
+++ b/contracts/paymasters/GaslessPaymaster.sol
@@ -6,7 +6,7 @@ import {Transaction} from '@matterlabs/zksync-contracts/l2/system-contracts/libr
 import {BOOTLOADER_FORMAL_ADDRESS} from '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
 import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 import {Errors} from '../libraries/Errors.sol';
-import {IClaveRegistry} from '../interfaces/IClaveRegistry.sol';
+import {IAGWRegistry} from '../interfaces/IAGWRegistry.sol';
 import {BootloaderAuth} from '../auth/BootloaderAuth.sol';
 
 /**
@@ -17,9 +17,9 @@ contract GaslessPaymaster is IPaymaster, Ownable, BootloaderAuth {
     uint256 public maxSponsoredEth = 0.001 ether;
     // User tx limit per paymaster
     uint256 public userLimit;
-    // Clave account registry contract
-    address public claveRegistry;
-    address public claveRegistry2;
+    // AGW account registry contract
+    address public agwRegistry;
+    address public agwRegistry2;
 
     // Store users sponsored tx count
     mapping(address => uint256) public userSponsored;
@@ -37,11 +37,11 @@ contract GaslessPaymaster is IPaymaster, Ownable, BootloaderAuth {
 
     /**
      * @notice Constructor functino of the paymaster
-     * @param registry address - Clave registry address
+     * @param registry address - AGW registry address
      * @param limit uint256    - User sponsorship limit
      */
     constructor(address registry, uint256 limit, address _owner) Ownable(_owner) {
-        claveRegistry = registry;
+        agwRegistry = registry;
         userLimit = limit;
     }
 
@@ -68,8 +68,8 @@ contract GaslessPaymaster is IPaymaster, Ownable, BootloaderAuth {
         if (limitlessAddresses[userAddress]) {
             // Allow limitlessAddresses to use paymaster freely
         } else if (
-            IClaveRegistry(claveRegistry).isClave(userAddress) ||
-            IClaveRegistry(claveRegistry2).isClave(userAddress)
+            IAGWRegistry(agwRegistry).isAGW(userAddress) ||
+            IAGWRegistry(agwRegistry2).isAGW(userAddress)
         ) {
             // Check if the account is a Clave account
             // Then, check the user sponsorship limit and decrease
@@ -77,7 +77,7 @@ contract GaslessPaymaster is IPaymaster, Ownable, BootloaderAuth {
             if (txAmount >= userLimit) revert Errors.USER_LIMIT_REACHED();
             userSponsored[userAddress]++;
         } else {
-            revert Errors.NOT_CLAVE_ACCOUNT();
+            revert Errors.NOT_AGW_ACCOUNT();
         }
 
         // Required ETH and token to pay fees
@@ -183,20 +183,20 @@ contract GaslessPaymaster is IPaymaster, Ownable, BootloaderAuth {
     }
 
     /**
-     * @notice Change the Clave registry address
-     * @param newRegistry address - New Clave registry address
+     * @notice Change the AGW registry address
+     * @param newRegistry address - New AGW registry address
      * @dev Only owner address can call this method
      */
-    function changeClaveRegistry(address newRegistry) external onlyOwner {
-        claveRegistry = newRegistry;
+    function changeRegistry(address newRegistry) external onlyOwner {
+        agwRegistry = newRegistry;
     }
 
     /**
-     * @notice Change the Clave registry2 address
-     * @param newRegistry address - New Clave registry2 address
+     * @notice Change the AGW registry2 address
+     * @param newRegistry address - New AGW registry2 address
      * @dev Only owner address can call this method
      */
-    function changeClaveRegistry2(address newRegistry) external onlyOwner {
-        claveRegistry2 = newRegistry;
+    function changeRegistry2(address newRegistry) external onlyOwner {
+        agwRegistry2 = newRegistry;
     }
 }

--- a/contracts/test/MockHook.sol
+++ b/contracts/test/MockHook.sol
@@ -6,7 +6,7 @@ import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
 import {IValidationHook, IExecutionHook} from '../interfaces/IHook.sol';
 
-interface IClave {
+interface IAGWAccount {
     function setHookData(bytes32 key, bytes calldata data) external;
 
     function getHookData(address hook, bytes32 key) external view returns (bytes memory);
@@ -29,7 +29,7 @@ contract MockValidationHook is IValidationHook {
     }
 
     function setHookData(address account, bytes32 key, bytes calldata data) external {
-        IClave(account).setHookData(key, data);
+        IAGWAccount(account).setHookData(key, data);
     }
 
     function getHookData(
@@ -37,7 +37,7 @@ contract MockValidationHook is IValidationHook {
         address hook,
         bytes32 key
     ) external view returns (bytes memory) {
-        return IClave(account).getHookData(hook, key);
+        return IAGWAccount(account).getHookData(hook, key);
     }
 
     function isInited(address account) external view returns (bool) {
@@ -70,7 +70,7 @@ contract MockExecutionHook is IExecutionHook {
     }
 
     function setHookData(address account, bytes32 key, bytes calldata data) external {
-        IClave(account).setHookData(key, data);
+        IAGWAccount(account).setHookData(key, data);
     }
 
     function getHookData(
@@ -78,7 +78,7 @@ contract MockExecutionHook is IExecutionHook {
         address hook,
         bytes32 key
     ) external view returns (bytes memory) {
-        return IClave(account).getHookData(hook, key);
+        return IAGWAccount(account).getHookData(hook, key);
     }
 
     function isInited(address account) external view returns (bool) {

--- a/contracts/test/MockModule.sol
+++ b/contracts/test/MockModule.sol
@@ -5,7 +5,7 @@ import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
 import {IModule} from '../interfaces/IModule.sol';
 
-interface IClave {
+interface IAGWAccount {
     function executeFromModule(address to, uint256 value, bytes memory data) external;
 
     function k1AddOwner(address addr) external;
@@ -24,11 +24,11 @@ contract MockModule is IModule {
 
     function testExecuteFromModule(address account, address to) external {
         uint256 value = values[account];
-        IClave(account).executeFromModule(to, value, '');
+        IAGWAccount(account).executeFromModule(to, value, '');
     }
 
     function testOnlySelfOrModule(address account) external {
-        IClave(account).k1AddOwner(address(this));
+        IAGWAccount(account).k1AddOwner(address(this));
     }
 
     function isInited(address account) external view returns (bool) {

--- a/contracts/test/MockStorage.sol
+++ b/contracts/test/MockStorage.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.17;
 
 library MockStorage {
-    //keccak256('clave.contracts.ClaveStorage') - 1
-    bytes32 private constant CLAVE_STORAGE_SLOT =
-        0x3248da1aeae8bd923cbf26901dc4bfc6bb48bb0fbc5b6102f1151fe7012884f4;
+    //keccak256('agw.contracts.AGWStorage') - 1
+    bytes32 private constant AGW_STORAGE_SLOT =
+        0x67641650ff26a63f6b1fb8b1cb96de5bac5c28fcfcca35c9518ea6966d32d42d;
 
     struct Layout {
         // ┌───────────────────┐
@@ -48,7 +48,7 @@ library MockStorage {
     }
 
     function layout() internal pure returns (Layout storage l) {
-        bytes32 slot = CLAVE_STORAGE_SLOT;
+        bytes32 slot = AGW_STORAGE_SLOT;
         assembly {
             l.slot := slot
         }

--- a/test/accounts/managers/hookmanager.test.ts
+++ b/test/accounts/managers/hookmanager.test.ts
@@ -16,7 +16,7 @@ import { addHook, removeHook } from '../../utils/managers/hookmanager';
 import { HOOKS, VALIDATORS } from '../../utils/names';
 import { ethTransfer, prepareEOATx } from '../../utils/transactions';
 
-describe('Clave Contracts - Hook Manager tests', () => {
+describe('AGW Contracts - Hook Manager tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/managers/modulemanager.test.ts
+++ b/test/accounts/managers/modulemanager.test.ts
@@ -16,7 +16,7 @@ import { addModule, removeModule } from '../../utils/managers/modulemanager';
 import { VALIDATORS } from '../../utils/names';
 import { prepareEOATx } from '../../utils/transactions';
 
-describe('Clave Contracts - Module Manager tests', () => {
+describe('AGW Contracts - Module Manager tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/managers/ownermanager.test.ts
+++ b/test/accounts/managers/ownermanager.test.ts
@@ -26,7 +26,7 @@ import { encodePublicKey, genKey } from '../../utils/p256';
 import { ethTransfer, prepareEOATx, prepareTeeTx } from '../../utils/transactions';
 import { addR1Validator } from '../../utils/managers/validatormanager';
 
-describe('Clave Contracts - Owner Manager tests', () => {
+describe('AGW Contracts - Owner Manager tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/managers/upgrademanager.test.ts
+++ b/test/accounts/managers/upgrademanager.test.ts
@@ -16,7 +16,7 @@ import { upgradeTx } from '../../utils/managers/upgrademanager';
 import { VALIDATORS } from '../../utils/names';
 import { HDNodeWallet } from 'ethers';
 
-describe('Clave Contracts - Upgrade Manager tests', () => {
+describe('AGW Contracts - Upgrade Manager tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/managers/validatormanager.test.ts
+++ b/test/accounts/managers/validatormanager.test.ts
@@ -23,7 +23,7 @@ import { ethTransfer, prepareTeeTx } from '../../utils/transactions';
 import { encodePublicKey } from '../../utils/p256';
 import { addR1Key } from '../../utils/managers/ownermanager';
 
-describe('Clave Contracts - Validator Manager tests', () => {
+describe('AGW Contracts - Validator Manager tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/modules/cloudrecovery.test.ts
+++ b/test/accounts/modules/cloudrecovery.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../utils/recovery/recovery';
 import { addR1Validator } from '../../utils/managers/validatormanager';
 
-describe('Clave Contracts - Cloud Recovery tests', () => {
+describe('AGW Contracts - Cloud Recovery tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/modules/socialrecovery.test.ts
+++ b/test/accounts/modules/socialrecovery.test.ts
@@ -25,7 +25,7 @@ import {
 import { ethTransfer, prepareTeeTx } from '../../utils/transactions';
 import { addR1Validator } from '../../utils/managers/validatormanager';
 
-describe('Clave Contracts - Social Recovery tests', () => {
+describe('AGW Contracts - Social Recovery tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/transactions.test.ts
+++ b/test/accounts/transactions.test.ts
@@ -21,7 +21,7 @@ import {
 import { VALIDATORS } from '../utils/names';
 import { ec } from 'elliptic';
 
-describe('Clave Contracts - Account tests', () => {
+describe('AGW Contracts - Account tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/validators/eoavalidator.test.ts
+++ b/test/accounts/validators/eoavalidator.test.ts
@@ -24,7 +24,7 @@ import {
     prepareMockTx,
 } from '../../utils/transactions';
 
-describe('Clave Contracts - EOA Validator tests', () => {
+describe('AGW Contracts - EOA Validator tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/validators/passkeyvalidator.test.ts
+++ b/test/accounts/validators/passkeyvalidator.test.ts
@@ -24,7 +24,7 @@ import { addR1Validator } from '../../utils/managers/validatormanager';
 import { encodePublicKey, genKey } from '../../utils/p256';
 import { addR1Key } from '../../utils/managers/ownermanager';
 
-describe('Clave Contracts - Passkey Validator tests', () => {
+describe('AGW Contracts - Passkey Validator tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/accounts/validators/teevalidator.test.ts
+++ b/test/accounts/validators/teevalidator.test.ts
@@ -24,7 +24,7 @@ import { addR1Validator } from '../../utils/managers/validatormanager';
 import { encodePublicKey } from '../../utils/p256';
 import { addR1Key } from '../../utils/managers/ownermanager';
 
-describe('Clave Contracts - TEE Validator tests', () => {
+describe('AGW Contracts - TEE Validator tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/deployments/deployer.test.ts
+++ b/test/deployments/deployer.test.ts
@@ -16,7 +16,7 @@ import { ClaveDeployer } from '../utils/deployer';
 import { fixture } from '../utils/fixture';
 import { VALIDATORS } from '../utils/names';
 
-describe('Clave Contracts - Deployer class tests', () => {
+describe('AGW Contracts - Deployer class tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/deployments/deployer.test.ts
+++ b/test/deployments/deployer.test.ts
@@ -98,8 +98,8 @@ describe('AGW Contracts - Deployer class tests', () => {
             const accountAddress = await account.getAddress();
             const factoryAddress = await factory.getAddress();
 
-            expect(await registry.isClave(accountAddress)).to.be.true;
-            expect(await registry.isClave(factoryAddress)).not.to.be.true;
+            expect(await registry.isAGW(accountAddress)).to.be.true;
+            expect(await registry.isAGW(factoryAddress)).not.to.be.true;
         });
 
         it('should not deploy an account with an invalid salt', async () => {

--- a/test/paymasters/erc20paymaster.test.ts
+++ b/test/paymasters/erc20paymaster.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../utils/transactions';
 import { ec } from 'elliptic';
 
-describe('Clave Contracts - ERC-20 Paymaster tests', () => {
+describe('AGW Contracts - ERC-20 Paymaster tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/paymasters/gaslesspaymaster.test.ts
+++ b/test/paymasters/gaslesspaymaster.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../utils/transactions';
 import { ec } from 'elliptic';
 
-describe('Clave Contracts - Gasless Paymaster tests', () => {
+describe('AGW Contracts - Gasless Paymaster tests', () => {
     let deployer: ClaveDeployer;
     let provider: Provider;
     let richWallet: Wallet;

--- a/test/utils/names.ts
+++ b/test/utils/names.ts
@@ -5,9 +5,9 @@
  */
 
 export const CONTRACT_NAMES = {
-    REGISTRY: 'ClaveRegistry',
-    IMPLEMENTATION: 'ClaveImplementation',
-    PROXY: 'ClaveProxy',
+    REGISTRY: 'AGWRegistry',
+    IMPLEMENTATION: 'AGWAccount',
+    PROXY: 'AccountProxy',
     FACTORY: 'AccountFactory',
     MOCK_VALIDATOR: 'MockValidator',
 };


### PR DESCRIPTION
Leave attribution for original Clave contracts, but rename anything referencing Clave in the actual contract code to ensure that these are clearly AGW contracts onchain.